### PR TITLE
[#19]Feat: 북마크 전역 상태 관리 훅 추가 및 저장된 공고 페이지 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -8,6 +8,7 @@ import ProfileSettingPage from './pages/ProfileSetting/ProfileSettingPage';
 import CategoryPage from './pages/Category/CategoryPage';
 import LatestPage from './pages/LatestPage/LatestPage';
 import DuePage from './pages/DuePage/DuePage';
+import BookmarkedNoticesPage from './pages/BookmarkedNotices/BookmarkedNoticesPage';
 
 const RootPage = () => {
   const navigate = useNavigate();
@@ -61,6 +62,14 @@ const router = createBrowserRouter([
         element: (
           <Layout showHeader showFooter headerProps={{ type: 'main' }}>
             <ProfileSettingPage />
+          </Layout>
+        ),
+      },
+      {
+        path: 'bookmarked',
+        element: (
+          <Layout showHeader showFooter headerProps={{ type: 'main' }}>
+            <BookmarkedNoticesPage />
           </Layout>
         ),
       },

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -15,7 +15,9 @@ function Drawer({ isOpen, onClose }: DrawerProps) {
           <S.MenuItem onClick={() => navigate('/service-intro')}>
             서비스 소개
           </S.MenuItem>
-          <S.MenuItem>저장한 공고</S.MenuItem>
+          <S.MenuItem onClick={() => navigate('/bookmarked')}>
+            저장한 공고
+          </S.MenuItem>
           <S.MenuItem onClick={() => navigate('/profile-setting')}>
             개인 설정
           </S.MenuItem>

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+const LOCAL_STORAGE_KEY = 'bookmarkedIds';
+
+export function useBookmark() {
+  const [bookmarkedIds, setBookmarkedIds] = useState<string[]>(() => {
+    const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  const toggleBookmark = (id: string) => {
+    setBookmarkedIds((prev) => {
+      const isBookmarked = prev.includes(id);
+      const next = isBookmarked ? prev.filter((x) => x !== id) : [...prev, id];
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  };
+
+  return { bookmarkedIds, toggleBookmark };
+}

--- a/src/pages/BookmarkedNotices/BookmarkedNoticesPage.styles.ts
+++ b/src/pages/BookmarkedNotices/BookmarkedNoticesPage.styles.ts
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+
+export const Stage = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  padding: 0;
+  background: transparent;
+  display: flex;
+  justify-content: center;
+`;
+
+export const Page = styled.div`
+  width: 375px;
+  min-height: 100vh;
+  height: auto;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  background: #f4f6f4;
+  position: relative;
+  overflow-x: hidden;
+`;
+
+export const Content = styled.main`
+  flex: 1 1 auto;
+  display: block;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  overflow-y: auto;
+`;
+
+export const Head = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  margin-top: 8px;
+`;
+
+export const Add = styled.button`
+  border: 0;
+  background: transparent;
+  font-size: 20px;
+  color: black;
+  cursor: pointer;
+`;
+
+export const ListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px 16px 80px;
+`;
+
+export const EmptyText = styled.p`
+  color: #555;
+  font-size: 16px;
+  text-align: center;
+  margin-top: 56px;
+`;

--- a/src/pages/BookmarkedNotices/BookmarkedNoticesPage.tsx
+++ b/src/pages/BookmarkedNotices/BookmarkedNoticesPage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import * as S from './BookmarkedNoticesPage.styles';
+import NoticeCard from '../../components/Card/NoticeCard';
+import { mapBackendList, MOCK_BACKEND_LATEST } from '../../data/notices';
+import { useBookmark } from '../../hooks/useBookmark'; // 북마크 훅 import
+
+export default function BookmarkedNoticesPage() {
+  const { bookmarkedIds, toggleBookmark } = useBookmark();
+
+  // 공고 데이터 (API 호출을 이미 커스텀 훅으로 처리한다면 그곳에서 읽어와도 됨)
+  const notices = mapBackendList(MOCK_BACKEND_LATEST);
+
+  // 북마크된 공고만 필터링
+  const bookmarkedNotices = notices.filter((n) => bookmarkedIds.includes(n.id));
+
+  return (
+    <S.Stage>
+      <S.Page>
+        <S.Content>
+          {bookmarkedNotices.length === 0 ? (
+            <S.EmptyText>저장한 공고가 없습니다.</S.EmptyText>
+          ) : (
+            <S.ListContainer>
+              {bookmarkedNotices.map((n) => (
+                <NoticeCard
+                  key={n.id}
+                  {...n}
+                  bookmarked={true} // 저장공고는 모두 북마크 상태
+                  onToggleBookmark={() => toggleBookmark(n.id)} // 토글 콜백 전달
+                />
+              ))}
+            </S.ListContainer>
+          )}
+        </S.Content>
+      </S.Page>
+    </S.Stage>
+  );
+}

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -12,6 +12,8 @@ import FabChat from '../../components/FabChat';
 import { useLatestNotices, useDueSoonNotices } from '../../hooks/notices';
 import Fallback from '../../components/common/Fallback';
 
+import { useBookmark } from '../../hooks/useBookmark';
+
 export default function MainPage() {
   const {
     list: latest,
@@ -23,6 +25,9 @@ export default function MainPage() {
     loading: dLoading,
     error: dError,
   } = useDueSoonNotices(200);
+
+  // 북마크 상태
+  const { bookmarkedIds, toggleBookmark } = useBookmark();
 
   return (
     <S.Stage>
@@ -41,7 +46,12 @@ export default function MainPage() {
               empty={!lLoading && !lError && latest.slice(0, 3).length === 0}
             >
               {latest.slice(0, 3).map((n) => (
-                <NoticeCard key={n.id} {...n} />
+                <NoticeCard
+                  key={n.id}
+                  {...n}
+                  bookmarked={bookmarkedIds.includes(n.id)} // 북마크 여부 전달
+                  onToggleBookmark={() => toggleBookmark(n.id)} // 토글 함수 전달
+                />
               ))}
             </Fallback>
           </SectionList>
@@ -54,7 +64,12 @@ export default function MainPage() {
               empty={!dLoading && !dError && due.slice(0, 3).length === 0}
             >
               {due.slice(0, 3).map((n) => (
-                <NoticeCard key={n.id} {...n} />
+                <NoticeCard
+                  key={n.id}
+                  {...n}
+                  bookmarked={bookmarkedIds.includes(n.id)}
+                  onToggleBookmark={() => toggleBookmark(n.id)}
+                />
               ))}
             </Fallback>
           </SectionList>


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

## 작업 내용 (변경 사항)
- useBookmark 훅을 만들어 로컬스토리지와 연동해 북마크 상태를 관리함
- 메인페이지와 저장된 공고 페이지 모두 이 훅을 사용해 상태 공유 및 동기화 가능